### PR TITLE
AuthToken Optional and Verbose logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odoh-client-rs-akamai"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "Alex Schultz <aschultz@akamai.com>" ]
 edition = "2018"
 license = "BSD-2-Clause"

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ use std::fs::File;
 use std::io::Read;
 use serde::{Deserialize, Serialize};
 extern crate base64;
-// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::str::FromStr;
 
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,4 +1,7 @@
 [server]
-target = "https://odoh-conf-service.default.hh.appbattery.shared.qa.akamai.com"
+#target = "https://odoh-conf-service.default.hh.appbattery.shared.qa.akamai.com"
+#cert = "/home/dpatel/workspace/client-tools/odoh_client/rama-testnet.pem"
+target = "https://config.odoh.staging.akamaiapis.net"
+cert = "/home/dpatel/workspace/client-tools/odoh_client/dpatel.pem"
 #target = "https://obliviousx7.r704.doh.names.test.dns.aka-mcqa.com:443"
-cert = "/home/dpatel/workspace/client-tools/odoh_client/rama-testnet.pem"
+

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,7 +1,3 @@
 [server]
-#target = "https://odoh-conf-service.default.hh.appbattery.shared.qa.akamai.com"
-#cert = "/home/dpatel/workspace/client-tools/odoh_client/rama-testnet.pem"
 target = "https://config.odoh.staging.akamaiapis.net"
-cert = "/home/dpatel/workspace/client-tools/odoh_client/dpatel.pem"
-#target = "https://obliviousx7.r704.doh.names.test.dns.aka-mcqa.com:443"
 


### PR DESCRIPTION
Auth Token is not available in production so made it optional
Added some verbose logging for Failed API request debugging with Response Headers as requested
ODoH Config gets printed in verbose logging
Added capability to make oDoH request to target using ODoHConfig binary file
Added long help for new parameters. Can be seen using --help.